### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 将棋AIエンジンのHTTP APIブリッジおよびMCP（Model Context Protocol）サーバー実装です。
 
-https://github.com/user-attachments/assets/cdff97b9-d60f-411b-b81f-9cabd8e62d62
+<a href="https://glama.ai/mcp/servers/@azumausu/shogi-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@azumausu/shogi-mcp/badge" alt="Shogi Server MCP server" />
+</a>
+
+https://github.com/user-attachments/assets/cdff97b9-d60f-411b-b81f-9cabd8e62
 
 
 将棋AIエンジンのREST APIおよびMCP（Model Context Protocol）サーバー実装です。  


### PR DESCRIPTION
This PR adds a badge for the [Shogi MCP Server](https://glama.ai/mcp/servers/@azumausu/shogi-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@azumausu/shogi-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@azumausu/shogi-mcp/badge" alt="Shogi Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.